### PR TITLE
feat: add TimelineAction support to TimelinePin

### DIFF
--- a/common-api/src/main/kotlin/io/rebble/pebblekit2/common/model/TimelinePin.kt
+++ b/common-api/src/main/kotlin/io/rebble/pebblekit2/common/model/TimelinePin.kt
@@ -50,22 +50,14 @@ public data class TimelinePin(
  *
  * @param title label shown in the action menu
  * @param type what the action does when selected
- * @param launchCode uint32 passed to the watchapp as launch args ([TimelineActionType.OPEN_WATCH_APP] only)
+ * @param launchCode passed to the watchapp as launch args ([TimelineActionType.OPEN_WATCH_APP] only)
  */
 public data class TimelineAction(
     val title: String,
     val type: TimelineActionType = TimelineActionType.OPEN_WATCH_APP,
-    val launchCode: Long? = null,
+    val launchCode: UInt? = null,
 ) {
-    init {
-        require(launchCode == null || launchCode in 0..MAX_LAUNCH_CODE) {
-            "launchCode must fit in an unsigned 32-bit integer, got $launchCode"
-        }
-    }
-
-    public companion object {
-        private const val MAX_LAUNCH_CODE: Long = 0xFFFFFFFFL
-    }
+    public companion object
 }
 
 public enum class TimelineActionType(public val code: String) {

--- a/common-api/src/main/kotlin/io/rebble/pebblekit2/common/model/TimelinePin.kt
+++ b/common-api/src/main/kotlin/io/rebble/pebblekit2/common/model/TimelinePin.kt
@@ -31,7 +31,48 @@ public data class TimelinePin(
      * Each reminder is inserted into BlobDatabase.Reminder and linked to this pin.
      */
     val reminders: List<TimelineReminder> = emptyList(),
+
+    /**
+     * Optional actions shown in the pin's action menu on the watch, before the
+     * system-provided "Remove" action.
+     */
+    val actions: List<TimelineAction> = emptyList(),
 ) {
+    public companion object
+}
+
+/**
+ * An action in a [TimelinePin]'s action menu.
+ *
+ * An [OPEN_WATCH_APP][TimelineActionType.OPEN_WATCH_APP] action launches the watchapp the pin is
+ * parented to. The watchapp sees launch reason `timelineAction` and receives [launchCode] via
+ * `launch_get_args()`, allowing the pin to deep-link to content inside the app.
+ *
+ * @param title label shown in the action menu
+ * @param type what the action does when selected
+ * @param launchCode uint32 passed to the watchapp as launch args ([TimelineActionType.OPEN_WATCH_APP] only)
+ */
+public data class TimelineAction(
+    val title: String,
+    val type: TimelineActionType = TimelineActionType.OPEN_WATCH_APP,
+    val launchCode: Long? = null,
+) {
+    init {
+        require(launchCode == null || launchCode in 0..MAX_LAUNCH_CODE) {
+            "launchCode must fit in an unsigned 32-bit integer, got $launchCode"
+        }
+    }
+
+    public companion object {
+        private const val MAX_LAUNCH_CODE: Long = 0xFFFFFFFFL
+    }
+}
+
+public enum class TimelineActionType(public val code: String) {
+    OPEN_WATCH_APP("openWatchApp"),
+    HTTP("http"),
+    ;
+
     public companion object
 }
 

--- a/common/src/main/kotlin/io/rebble/pebblekit2/common/model/TimelinePinSerialization.kt
+++ b/common/src/main/kotlin/io/rebble/pebblekit2/common/model/TimelinePinSerialization.kt
@@ -36,7 +36,7 @@ public fun TimelineAction.Companion.fromBundle(bundle: Bundle): TimelineAction {
         title = bundle.getString(KEY_ACTION_TITLE) ?: error("missing action title"),
         type = type,
         launchCode = if (bundle.containsKey(KEY_ACTION_LAUNCH_CODE)) {
-            bundle.getLong(KEY_ACTION_LAUNCH_CODE)
+            bundle.getLong(KEY_ACTION_LAUNCH_CODE).toUInt()
         } else {
             null
         },
@@ -72,7 +72,7 @@ public fun TimelineAction.toBundle(): Bundle {
     return Bundle().apply {
         putString(KEY_ACTION_TITLE, title)
         putString(KEY_ACTION_TYPE, type.code)
-        launchCode?.let { putLong(KEY_ACTION_LAUNCH_CODE, it) }
+        launchCode?.let { putLong(KEY_ACTION_LAUNCH_CODE, it.toLong()) }
     }
 }
 

--- a/common/src/main/kotlin/io/rebble/pebblekit2/common/model/TimelinePinSerialization.kt
+++ b/common/src/main/kotlin/io/rebble/pebblekit2/common/model/TimelinePinSerialization.kt
@@ -10,12 +10,36 @@ public fun TimelinePin.Companion.fromBundle(bundle: Bundle): TimelinePin {
     val reminders = (0 until reminderCount).map { i ->
         TimelineReminder.fromBundle(bundle.getBundle("$KEY_REMINDER_PREFIX$i") ?: Bundle())
     }
+    val actionCount = bundle.getInt(KEY_ACTIONS_COUNT, 0)
+    val actions = (0 until actionCount).map { i ->
+        TimelineAction.fromBundle(bundle.getBundle("$KEY_ACTION_PREFIX$i") ?: Bundle())
+    }
     return TimelinePin(
         id = bundle.getString(KEY_ID) ?: error("missing id"),
         startTime = Instant.parse(bundle.getString(KEY_START_TIME) ?: error("missing start time")),
         duration = bundle.getString(KEY_DURATION)?.let { Duration.parse(it) },
         layout = TimelineLayout.fromBundle(bundle),
         reminders = reminders,
+        actions = actions,
+    )
+}
+
+public fun TimelineAction.Companion.fromBundle(bundle: Bundle): TimelineAction {
+    val typeCode = bundle.getString(KEY_ACTION_TYPE).orEmpty()
+    val type = TimelineActionType.entries.firstOrNull { it.code == typeCode }
+        ?: run {
+            Logger.withTag("PebbleKit")
+                .e { "Got unknown action type '$typeCode' while decoding TimelinePin" }
+            TimelineActionType.OPEN_WATCH_APP
+        }
+    return TimelineAction(
+        title = bundle.getString(KEY_ACTION_TITLE) ?: error("missing action title"),
+        type = type,
+        launchCode = if (bundle.containsKey(KEY_ACTION_LAUNCH_CODE)) {
+            bundle.getLong(KEY_ACTION_LAUNCH_CODE)
+        } else {
+            null
+        },
     )
 }
 
@@ -37,6 +61,18 @@ public fun TimelinePin.toBundle(): Bundle {
         reminders.forEachIndexed { i, reminder ->
             putBundle("$KEY_REMINDER_PREFIX$i", reminder.toBundle())
         }
+        putInt(KEY_ACTIONS_COUNT, actions.size)
+        actions.forEachIndexed { i, action ->
+            putBundle("$KEY_ACTION_PREFIX$i", action.toBundle())
+        }
+    }
+}
+
+public fun TimelineAction.toBundle(): Bundle {
+    return Bundle().apply {
+        putString(KEY_ACTION_TITLE, title)
+        putString(KEY_ACTION_TYPE, type.code)
+        launchCode?.let { putLong(KEY_ACTION_LAUNCH_CODE, it) }
     }
 }
 
@@ -107,3 +143,8 @@ private const val KEY_LAYOUT_LAST_UPDATED = "LAYOUT_LAST_UPDATED"
 private const val KEY_REMINDERS_COUNT = "REMINDERS_COUNT"
 private const val KEY_REMINDER_PREFIX = "REMINDER_"
 private const val KEY_REMINDER_TIME = "REMINDER_TIME"
+private const val KEY_ACTIONS_COUNT = "ACTIONS_COUNT"
+private const val KEY_ACTION_PREFIX = "ACTION_"
+private const val KEY_ACTION_TITLE = "ACTION_TITLE"
+private const val KEY_ACTION_TYPE = "ACTION_TYPE"
+private const val KEY_ACTION_LAUNCH_CODE = "ACTION_LAUNCH_CODE"


### PR DESCRIPTION
## Summary

Adds an optional `actions` list to `TimelinePin` so companion apps can put actions in a pin's action menu on the watch — most importantly `OPEN_WATCH_APP`, which launches the watchapp the pin is parented to and passes an optional uint32 `launchCode` through `launch_get_args()`, letting the pin deep-link to the content it represents (e.g. a calendar companion opening the exact event).

Mirrors how `reminders` landed in #14:

- **common-api**: `TimelineAction(title, type, launchCode)` + `TimelineActionType` (`OPEN_WATCH_APP`, `HTTP`), new `actions: List<TimelineAction> = emptyList()` on `TimelinePin`, KDoc on all of it. `launchCode` is validated to the unsigned 32-bit range.
- **common**: bundle round-trip (`ACTIONS_COUNT` / `ACTION_n` sub-bundles), with the same unknown-type fallback-and-log behavior as `TimelineLayoutType`.

Older Pebble app builds ignore the extra bundle keys, so pins from apps using this field degrade gracefully (pin inserts, actions dropped) — same compatibility story as reminders.

Host-side support to consume this is being wired into the mobile app's timeline emulator: coredevices/mobileapp#356 makes the emulator emit `openWatchApp` actions with the `LaunchCode` BlobDB attribute (firmware already handles the rest — `timeline.c` launches the pin's `parent_id` with `APP_LAUNCH_TIMELINE_ACTION`). A follow-up there will map this model into `TimelinePinJson` once this is released, the same sequence as #14 → the reminders forwarding PR.

## Testing

- `:common-api:check` and `:common:check` pass; `:client:assembleRelease` / `:server:assembleRelease` build.
- Round-trip verified by inspection against the reminder serialization it mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)